### PR TITLE
Fix reasoning_effort for gemini-2.5-pro

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -6429,6 +6429,7 @@
         "supports_video_input": true,
         "supports_pdf_input": true,
         "supports_response_schema": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -6687,6 +6688,7 @@
         "supports_video_input": true,
         "supports_pdf_input": true,
         "supports_response_schema": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -6729,6 +6731,50 @@
         "supports_video_input": true,
         "supports_pdf_input": true,
         "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supports_web_search": true
+    },
+    "gemini-2.5-pro": {
+        "max_tokens": 65535,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_images_per_prompt": 3000,
+        "max_videos_per_prompt": 10,
+        "max_video_length": 1,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_pdf_size_mb": 30,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_above_200k_tokens": 1.5e-05,
+        "litellm_provider": "vertex_ai-language-models",
+        "mode": "chat",
+        "rpm": 2000,
+        "tpm": 800000,
+        "supports_system_messages": true,
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "supports_audio_input": true,
+        "supports_video_input": true,
+        "supports_pdf_input": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supported_endpoints": [
             "/v1/chat/completions",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6429,6 +6429,7 @@
         "supports_video_input": true,
         "supports_pdf_input": true,
         "supports_response_schema": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -6687,6 +6688,7 @@
         "supports_video_input": true,
         "supports_pdf_input": true,
         "supports_response_schema": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -6729,6 +6731,50 @@
         "supports_video_input": true,
         "supports_pdf_input": true,
         "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supports_web_search": true
+    },
+    "gemini-2.5-pro": {
+        "max_tokens": 65535,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_images_per_prompt": 3000,
+        "max_videos_per_prompt": 10,
+        "max_video_length": 1,
+        "max_audio_length_hours": 8.4,
+        "max_audio_per_prompt": 1,
+        "max_pdf_size_mb": 30,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "output_cost_per_token": 1e-05,
+        "output_cost_per_token_above_200k_tokens": 1.5e-05,
+        "litellm_provider": "vertex_ai-language-models",
+        "mode": "chat",
+        "rpm": 2000,
+        "tpm": 800000,
+        "supports_system_messages": true,
+        "supports_function_calling": true,
+        "supports_vision": true,
+        "supports_audio_input": true,
+        "supports_video_input": true,
+        "supports_pdf_input": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supported_endpoints": [
             "/v1/chat/completions",


### PR DESCRIPTION
## Summary
- mark gemini 2.5 pro models as supporting reasoning
- add explicit entry for `gemini-2.5-pro` in the model map

## Testing
- `pytest tests/test_litellm/llms/gemini/test_gemini_tts.py::TestGeminiTTSTransformation::test_gemini_tts_supported_params -q`
- `python - <<'PY'
import os, importlib
os.environ['LITELLM_LOCAL_MODEL_COST_MAP']='True'
import litellm
importlib.reload(litellm)
from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexGeminiConfig
assert 'reasoning_effort' in VertexGeminiConfig().get_supported_openai_params('vertex_ai/gemini-2.5-pro')
print('test_passed')
PY

------
https://chatgpt.com/codex/tasks/task_e_68553ced33ec8328a4588a139c7d41d8